### PR TITLE
CI: Introduce new GitLab configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,9 @@ image: node
 stages:
   - release
 
+cache:
+  untracked: true
+
 .release:
   before_script:
     - wget https://github.com/github/hub/releases/download/v2.10.0/hub-linux-amd64-2.10.0.tgz
@@ -20,6 +23,7 @@ github_release:
     - tags
   script:
     - if [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - pwd
     - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -t $CI_COMMIT_SHA $CI_COMMIT_TAG
 
@@ -29,5 +33,6 @@ github_prelease:
     - tags
   script:
     - if ! [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - pwd
     - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -p -t $CI_COMMIT_SHA $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ github_release:
     - tags
   script:
     - if [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -t $CI_COMMIT_SHA $CI_COMMIT_TAG
 
 github_prelease:
@@ -28,4 +29,5 @@ github_prelease:
     - tags
   script:
     - if ! [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -p -t $CI_COMMIT_SHA $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,18 @@
 image: node
 
+variables:
+  HUB_VERSION: "2.10.0"
+
 stages:
   - release
 
 .release:
   before_script:
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y zip
-    - wget https://github.com/github/hub/releases/download/v2.10.0/hub-linux-amd64-2.10.0.tgz
-    - tar -xzf hub-linux-amd64-2.10.0.tgz
-    - mv hub-linux-amd64-2.10.0/bin/hub /usr/local/bin
-    - rm -rf hub-linux-amd64-2.10.0*
+    - wget https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz
+    - tar -xzf hub-linux-amd64-${HUB_VERSION}.tgz
+    - mv hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/local/bin
+    - rm -rf hub-linux-amd64-${HUB_VERSION}*
     - npm run create-release-package -- $CI_COMMIT_TAG
     - git remote rm origin
     - git remote add origin "https://github.com/$CI_PROJECT_PATH.git"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,6 @@ image: node
 stages:
   - release
 
-cache:
-  untracked: true
-
 .release:
   before_script:
     - apt update && DEBIAN_FRONTEND=noninteractive apt install -y zip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,13 +8,12 @@ cache:
 
 .release:
   before_script:
+    - apt update && DEBIAN_FRONTEND=noninteractive apt install -y zip
     - wget https://github.com/github/hub/releases/download/v2.10.0/hub-linux-amd64-2.10.0.tgz
     - tar -xzf hub-linux-amd64-2.10.0.tgz
     - mv hub-linux-amd64-2.10.0/bin/hub /usr/local/bin
     - rm -rf hub-linux-amd64-2.10.0*
     - npm run create-release-package -- $CI_COMMIT_TAG
-    - pwd
-    - find . -iname "*.zip"
     - git remote rm origin
     - git remote add origin "https://github.com/$CI_PROJECT_PATH.git"
   stage: release
@@ -25,8 +24,6 @@ github_release:
     - tags
   script:
     - if [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
-    - pwd
-    - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -t $CI_COMMIT_SHA $CI_COMMIT_TAG
 
 github_prelease:
@@ -35,6 +32,4 @@ github_prelease:
     - tags
   script:
     - if ! [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
-    - pwd
-    - find . -iname "*.zip"
     - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -p -t $CI_COMMIT_SHA $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+image: node
+
+stages:
+  - release
+
+.release:
+  before_script:
+    - wget https://github.com/github/hub/releases/download/v2.10.0/hub-linux-amd64-2.10.0.tgz
+    - tar -xzf hub-linux-amd64-2.10.0.tgz
+    - mv hub-linux-amd64-2.10.0/bin/hub /usr/local/bin
+    - rm -rf hub-linux-amd64-2.10.0*
+    - npm run create-release-package -- $CI_COMMIT_TAG
+    - git remote rm origin
+    - git remote add origin "https://github.com/$CI_PROJECT_PATH.git"
+  stage: release
+
+github_release:
+  extends: .release
+  only:
+    - tags
+  script:
+    - if [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -t $CI_COMMIT_SHA $CI_COMMIT_TAG
+
+github_prelease:
+  extends: .release
+  only:
+    - tags
+  script:
+    - if ! [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.zip" -exec echo -a {} \;) -p -t $CI_COMMIT_SHA $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,8 @@ cache:
     - mv hub-linux-amd64-2.10.0/bin/hub /usr/local/bin
     - rm -rf hub-linux-amd64-2.10.0*
     - npm run create-release-package -- $CI_COMMIT_TAG
+    - pwd
+    - find . -iname "*.zip"
     - git remote rm origin
     - git remote add origin "https://github.com/$CI_PROJECT_PATH.git"
   stage: release

--- a/scripts/create-release-package.sh
+++ b/scripts/create-release-package.sh
@@ -7,6 +7,11 @@ then
   exit 1
 fi
 
+if ! [ -x "$(command -v zip)" ]; then
+  echo 'Error: zip is NOT installed 💣' >&2
+  exit 1
+fi
+
 # get tag name as first argument
 tag_name=$1
 


### PR DESCRIPTION
This PR introduces a GitLab CI configuration to build `mirador-plugins` on our own infrastructure (Travis CI replacement).